### PR TITLE
Avoid generating texture when image is empty

### DIFF
--- a/addons/milestone/scripts/resource_icon_gen/preview_generator.gd
+++ b/addons/milestone/scripts/resource_icon_gen/preview_generator.gd
@@ -17,6 +17,9 @@ func _generate(resource, size, _metadata) -> Texture2D:
 				img = resource.icon.get_image()
 				img.resize(size.x, size.y, Image.INTERPOLATE_LANCZOS)
 
+	if img.is_empty():
+		return null
+
 	return ImageTexture.create_from_image(img)
 
 func _handles(type) -> bool:


### PR DESCRIPTION
This PR prevents multiple repeated errors like:

  ERROR: Invalid image: image is empty

These errors occurred when attempting to generate a texture from an empty image, usually when `icon` or `hidden_icon` resources were not set or were null.

A check was added to avoid creating the texture if the resulting image is empty (`img.is_empty()`), returning `null` in those cases instead.

This improves the stability of the preview system and prevents unnecessary error spam in the console.

<img width="523" height="269" alt="image" src="https://github.com/user-attachments/assets/cbb6bf9f-9323-4300-bca2-f27849d6d461" />
