### PR TITLE
Fix memory leak when closing game with active notification

### DIFF
--- a/addons/milestone/scripts/achievements/achievement_notifier.gd
+++ b/addons/milestone/scripts/achievements/achievement_notifier.gd
@@ -324,9 +324,14 @@ func _get_notification_by_id(achievement_id: String) -> Node:
 
 func clear_notifications() -> void:
 	for notif in _active_notifications:
+		_notification_timers[notif.id].stop()
+		_notification_timers[notif.id].emit_signal("timeout")
 		_notification_tweens[notif.id].kill()
 		notif.queue_free()
-	
+		
 	_active_notifications.clear()
 	_queue.clear()
 	_notification_timers.clear()
+
+func _exit_tree() -> void:
+	clear_notifications()


### PR DESCRIPTION
Properly frees AchievementNotifier and its resources on game exit to prevent errors from orphaned nodes and lambdas.

<img width="1919" height="362" alt="image" src="https://github.com/user-attachments/assets/3c3cc011-7f1e-4c4d-b4bc-74ed2726b486" />
